### PR TITLE
fix: file extension of report

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -17,7 +17,7 @@ module.exports =
               ? `./analyze/client.html`
               : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
                   options.nextRuntime
-                }.html`,
+                }${analyzerMode==="json" ? "json":"html"}`,
           })
         )
 


### PR DESCRIPTION
### Issue

When `analyzerMode` is selected as `json`, the bundle analyzer still emits a `.html` file. 

### Fix

Added a check for `analyzerMode` === `json` to determine file extension. 


